### PR TITLE
Added seekTo(msec) to the PlayerCallback to be able to detect the see…

### DIFF
--- a/src/de/guj/ems/mobile/sdk/controllers/video/IVideoPlayer.java
+++ b/src/de/guj/ems/mobile/sdk/controllers/video/IVideoPlayer.java
@@ -36,6 +36,11 @@ public interface IVideoPlayer {
          * Called when an error occurs during video playback.
          */
         void onError();
+
+        /**
+         * Called when the currently loaded video will be progressed to the given position (milliseconds).
+         */
+        void onSeekTo(int videoPosition);
     }
 
     /**

--- a/src/de/guj/ems/mobile/sdk/views/video/GuJEMSVideoPlayer.java
+++ b/src/de/guj/ems/mobile/sdk/views/video/GuJEMSVideoPlayer.java
@@ -263,6 +263,10 @@ public class GuJEMSVideoPlayer extends RelativeLayout {
 			}
 
 			@Override
+			public void onSeekTo(int videoPosition) {
+			}
+
+			@Override
 			public void onCompleted() {
 				if (mIsAdDisplayed) {
 					for (VideoAdPlayer.VideoAdPlayerCallback callback : mAdCallbacks) {

--- a/src/de/guj/ems/mobile/sdk/views/video/GuJEMSVideoView.java
+++ b/src/de/guj/ems/mobile/sdk/views/video/GuJEMSVideoView.java
@@ -148,6 +148,16 @@ public class GuJEMSVideoView extends VideoView implements IVideoPlayer {
     }
 
     @Override
+    public void seekTo(int msec) {
+        for (PlayerCallback callback : mVideoPlayerCallbacks) {
+            callback.onSeekTo(msec);
+        }
+        //Call super at the end because in most cases the listener wants to capture the current position
+        //before the seekTo method is executed, to calculate the delta to detect direction (backward / forward).
+        super.seekTo(msec);
+    }
+
+    @Override
     public void disablePlaybackControls() {
         setMediaController(null);
     }


### PR DESCRIPTION
…k direction for normal (no ad) player. This is very important for media tracking.

Hi, ich bin Andrei von Chefkoch GmbH. Für unser Media Tracking ist es wichtig zu wissen ob bei dem normalen Video Player der Nutzer gerade vor- oder zurückgespult hat. Daher dieser Pullrequest.
